### PR TITLE
Using multipart upload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'shrine', '~> 3.0.0.beta'
 gem 'sidekiq'
 gem 'streamio-ffmpeg'
 gem 'uglifier', '>= 1.3.0'
+gem 'uppy-s3_multipart', '~> 0.3'
 gem 'webpacker', '~> 4.x'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,8 @@ GEM
       ffi (~> 1.0)
     redis (4.1.2)
     regexp_parser (1.6.0)
+    roda (3.23.0)
+      rack
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -335,6 +337,10 @@ GEM
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.0)
+    uppy-s3_multipart (0.3.2)
+      aws-sdk-s3 (~> 1.0)
+      content_disposition (~> 1.0)
+      roda (>= 2.27, < 4)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -393,6 +399,7 @@ DEPENDENCIES
   sidekiq
   streamio-ffmpeg
   uglifier (>= 1.3.0)
+  uppy-s3_multipart (~> 0.3)
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.x)

--- a/app/javascript/packs/uppy.js
+++ b/app/javascript/packs/uppy.js
@@ -1,14 +1,14 @@
 import Uppy from '@uppy/core'
-import AwsS3 from '@uppy/aws-s3'
+import AwsS3Multipart from '@uppy/aws-s3-multipart'
 import StatusBar from '@uppy/status-bar'
 import FileInput from '@uppy/file-input'
 
 function fileUpload(fileInput) {
     var imagePreview = document.querySelector('.upload-preview')
-    
+
 
     fileInput.style.display = 'none' // uppy will add its own file input
-  
+
     var uppy = Uppy({
         id: fileInput.id,
         autoProceed: true,
@@ -26,16 +26,16 @@ function fileUpload(fileInput) {
     //   .use(Uppy.ThumbnailGenerator, {
     //     thumbnailWidth: 400,
     //   })
-  
-    uppy.use(AwsS3, {
-      companionUrl: '/', // will call Shrine's presign endpoint on `/s3/params`
+
+    uppy.use(AwsS3Multipart, {
+      companionUrl: '/',
     })
-  
+
     uppy.on('upload-success', function (file, response) {
       document.querySelector('.upload-submit').style.visibility='visible';
       // construct uploaded file data in the format that Shrine expects
       var uploadedFileData = JSON.stringify({
-        id: file.meta['key'].match(/^cache\/(.+)/)[1], // object key without prefix
+        id: response.uploadURL.match(/\/cache\/([^\?]+)/)[1],
         storage: 'cache',
         metadata: {
           size:      file.size,
@@ -43,21 +43,21 @@ function fileUpload(fileInput) {
           mime_type: file.type,
         }
       })
-  
+
       // set hidden field value to the uploaded file data so that it's submitted with the form as the attachment
       var hiddenInput = fileInput.parentNode.querySelector('.upload-hidden')
       hiddenInput.value = uploadedFileData
     })
-  
+
 //     uppy.on('thumbnail:generated', function (file, preview) {
 //       imagePreview.src = preview
 //     })
-  
+
     return uppy
   }
 
   document.querySelector('.upload-submit').style.visibility='hidden';
-  
+
   document.querySelectorAll('.upload-file').forEach(function (fileInput) {
     fileUpload(fileInput)
   })

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -26,15 +26,4 @@ Shrine.storages = {
 Shrine.plugin :activerecord
 Shrine.plugin :cached_attachment_data
 Shrine.plugin :restore_cached_data
-
-Shrine.plugin :presign_endpoint, presign_options: ->(request) {
-  # Uppy will send the "filename" and "type" query parameters
-  filename = request.params['filename']
-  type     = request.params['type']
-
-  {
-    content_disposition: "inline; filename=\"#{filename}\"",
-    content_type: type,
-    content_length_range: 0..(200000 * 1024 * 1024)
-  }
-}
+Shrine.plugin :uppy_s3_multipart

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  mount Shrine.presign_endpoint(:cache) => '/s3/params'
+  mount Shrine.uppy_s3_multipart(:cache) => '/s3/multipart'
 end

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
     "@uppy/aws-s3": "^1.3.0",
+    "@uppy/aws-s3-multipart": "^1.3.0",
     "@uppy/core": "^1.4.0",
     "@uppy/drag-drop": "^1.3.0",
     "@uppy/file-input": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,6 +777,15 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@uppy/aws-s3-multipart@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@uppy/aws-s3-multipart/-/aws-s3-multipart-1.3.0.tgz#8cbc1622733d829e4d0416e50a0b6d7227a04d96"
+  integrity sha512-AmGEz847Wf9zSBCIZpHzGs4osyWoFuiTP6BlSOFiXQF/F3qqOofp5lZNACC+M+P+hCDBuc4XcaWgfnd/9TINAw==
+  dependencies:
+    "@uppy/companion-client" "^1.3.0"
+    "@uppy/utils" "^1.3.0"
+    resolve-url "^0.2.1"
+
 "@uppy/aws-s3@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@uppy/aws-s3/-/aws-s3-1.3.0.tgz#543240ae8097ce84f5c3061f7be886ccec31b1e5"


### PR DESCRIPTION
I think this is what we want to use for multipart upload directly to S3. From what I can tell, it still does the same things as the previous direct upload, it's just doing it multipart-dly:

```
Started OPTIONS "/s3/multipart" for ::1 at 2019-09-10 21:45:26 -0400
Started POST "/s3/multipart" for ::1 at 2019-09-10 21:45:26 -0400
Started GET "/s3/multipart/DqbOfy7UFe2HO1AEMmdEsuXCFbxGsCVnm84xdY4UXq9ssNhyV9vY1C48tWVvCS1RpK.k_fSFFrIXTUXhZlaMfiiwrR0epcarwZmki99nuIMd1cOrWGZGvkolWjsLUrW6/1?key=cache%2Fa8a691bdb233963c0b74f3e47742fa12.mov" for ::1 at 2019-09-10 21:45:27 -0400
Started POST "/s3/multipart/DqbOfy7UFe2HO1AEMmdEsuXCFbxGsCVnm84xdY4UXq9ssNhyV9vY1C48tWVvCS1RpK.k_fSFFrIXTUXhZlaMfiiwrR0epcarwZmki99nuIMd1cOrWGZGvkolWjsLUrW6/complete?key=cache%2Fa8a691bdb233963c0b74f3e47742fa12.mov" for ::1 at 2019-09-10 21:45:33 -0400
Started POST "/posts" for ::1 at 2019-09-10 21:45:36 -0400
Processing by PostsController#create as HTML
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"h4nT79fM1M5cqyKx+76xuaEtAUKpHCXcM0CF4vqF8Wm6nu5v3WAncr+QmiUNFwtAXQUTjt1Hu68ot5YhRqwghg==", "post"=>{"title"=>"Vid", "file"=>"{\"id\":\"a8a691bdb233963c0b74f3e47742fa12.mov\",\"storage\":\"cache\",\"metadata\":{\"size\":1448367,\"filename\":\"file_example_MOV_1280_1_4MB.mov\",\"mime_type\":\"video/quicktime\"}}"}, "commit"=>"submit"}
```

The other nice feature is that you can pause and resume uploads:
<img width="478" alt="Screen Shot 2019-09-10 at 9 28 22 PM" src="https://user-images.githubusercontent.com/312085/64662266-c8d03200-d415-11e9-96ca-07d0f43089e2.png">
