### PR TITLE
Pg pvc

### DIFF
--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -33,7 +33,6 @@ spec:
           protocol: TCP
         resources: {}
         volumeMounts:
-          name: shared-data
         - mountPath: /var/lib/postgresql/data
           name: data
   volumeClaimTemplates:


### PR DESCRIPTION
adds persistence to the `ss-shrine` deployment