### PR TITLE
Uppy dashboard

### DIFF
--- a/app/javascript/packs/uppy.js
+++ b/app/javascript/packs/uppy.js
@@ -2,11 +2,9 @@ import Uppy from '@uppy/core'
 import AwsS3Multipart from '@uppy/aws-s3-multipart'
 import StatusBar from '@uppy/status-bar'
 import FileInput from '@uppy/file-input'
+import Dashboard from '@uppy/dashboard'
 
 function fileUpload(fileInput) {
-    var imagePreview = document.querySelector('.upload-preview')
-
-
     fileInput.style.display = 'none' // uppy will add its own file input
 
     var uppy = Uppy({
@@ -14,18 +12,11 @@ function fileUpload(fileInput) {
         autoProceed: true,
         allowMultipleUploads: false,
       })
-      .use(FileInput, {
-        target: fileInput.parentNode,
-        pretty: false,
+      .use(Dashboard, {
+        id: 'Dashboard',
+        target: 'body',
+        inline: 'true'
       })
-      .use(StatusBar, {
-        target: imagePreview.parentNode,
-        hideAfterFinish: false,
-        showProgressDetails: true,
-      })
-    //   .use(Uppy.ThumbnailGenerator, {
-    //     thumbnailWidth: 400,
-    //   })
 
     uppy.use(AwsS3Multipart, {
       companionUrl: '/',
@@ -48,10 +39,6 @@ function fileUpload(fileInput) {
       var hiddenInput = fileInput.parentNode.querySelector('.upload-hidden')
       hiddenInput.value = uploadedFileData
     })
-
-//     uppy.on('thumbnail:generated', function (file, preview) {
-//       imagePreview.src = preview
-//     })
 
     return uppy
   }

--- a/app/jobs/promote_job.rb
+++ b/app/jobs/promote_job.rb
@@ -5,7 +5,6 @@ class PromoteJob < ApplicationJob
 
   def perform(record:, name:, file_data:)
     attacher = Shrine::Attacher.retrieve(model: record, name: name.to_sym, file: file_data)
-    record.file_derivatives!(:derivatives)
     attacher.atomic_promote
   rescue Shrine::AttachmentChanged, ActiveRecord::RecordNotFound
   end

--- a/app/models/post_status.rb
+++ b/app/models/post_status.rb
@@ -9,7 +9,7 @@ class PostStatus
   end
 
   def completed?
-    promoted? && derived?
+    promoted?
   end
 
   def promoted?

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@uppy/aws-s3": "^1.3.0",
     "@uppy/aws-s3-multipart": "^1.3.0",
     "@uppy/core": "^1.4.0",
+    "@uppy/dashboard": "^1.3.0",
     "@uppy/drag-drop": "^1.3.0",
     "@uppy/file-input": "^1.3.0",
     "@uppy/informer": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,6 +816,26 @@
     namespace-emitter "^2.0.1"
     preact "8.2.9"
 
+"@uppy/dashboard@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@uppy/dashboard/-/dashboard-1.3.0.tgz#a197730be0bac38c730c4e90a500d147f9f76f60"
+  integrity sha512-VUe+8lmHKDjl7yho+yH9n2lXOOExsaGrOog5fPI52Ty5zoRbeCRgkYH6p8SIiK9p+EZH+dMGQWMLfE7mCrBJsw==
+  dependencies:
+    "@uppy/informer" "^1.3.0"
+    "@uppy/provider-views" "^1.3.0"
+    "@uppy/status-bar" "^1.3.0"
+    "@uppy/thumbnail-generator" "^1.3.0"
+    "@uppy/utils" "^1.3.0"
+    classnames "^2.2.6"
+    cuid "^2.1.1"
+    is-shallow-equal "^1.0.1"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    memoize-one "^5.0.4"
+    preact "8.2.9"
+    preact-css-transition-group "^1.3.0"
+    resize-observer-polyfill "^1.5.0"
+
 "@uppy/drag-drop@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@uppy/drag-drop/-/drag-drop-1.3.0.tgz#5e2a31f203d33c0451d4adb55185370296cb54f4"
@@ -840,6 +860,15 @@
     "@uppy/utils" "^1.3.0"
     preact "8.2.9"
 
+"@uppy/provider-views@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@uppy/provider-views/-/provider-views-1.3.0.tgz#2c209e1197d8326f05c980b7b67f83576b8e1594"
+  integrity sha512-AxpzAdtVmCCXUuh06wuQKQqRgMBQzhOJY92VMSd6UjrpIidltPdHloQxLdszT9xPOqOw4lkoK9nu7RjPvZmzWg==
+  dependencies:
+    "@uppy/utils" "^1.3.0"
+    classnames "^2.2.6"
+    preact "8.2.9"
+
 "@uppy/status-bar@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@uppy/status-bar/-/status-bar-1.3.0.tgz#71ae77c2fb2ce6262fb9e2844233aa8b480c5cf6"
@@ -854,6 +883,14 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@uppy/store-default/-/store-default-1.2.0.tgz#4007b84e6eef24b3f07b0fe5457548386cea77d9"
   integrity sha512-mnkxdX4DJMP2nrBklh5MXdn31bAyBSlCcp4+BZanFwv4WiCEpg/ruYzNzaJ1nVyuINJEDj2nx/DWxo+1F6WuWw==
+
+"@uppy/thumbnail-generator@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@uppy/thumbnail-generator/-/thumbnail-generator-1.3.0.tgz#d6174f260441d69e854b1d50581d71229a3fb557"
+  integrity sha512-qRfChsuykmxXrc51a5Ua3to1X3QJEL/hF3JwT1DUY2IMhFoOLhPLlFH3qpAHkeJLt1iNQYGbNO8aFTbNaGlSrA==
+  dependencies:
+    "@uppy/utils" "^1.3.0"
+    exif-js "2.3.0"
 
 "@uppy/utils@^1.3.0":
   version "1.3.0"
@@ -2670,6 +2707,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exif-js@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/exif-js/-/exif-js-2.3.0.tgz#9d10819bf571f873813e7640241255ab9ce1a814"
+  integrity sha1-nRCBm/Vx+HOBPnZAJBJVq5zhqBQ=
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -3730,6 +3772,11 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
+is-shallow-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shallow-equal/-/is-shallow-equal-1.0.1.tgz#c410b51eb1c12ee50cd02891d32d1691a132d73c"
+  integrity sha512-lq5RvK+85Hs5J3p4oA4256M1FEffzmI533ikeDHvJd42nouRRx5wBzt36JuviiGe5dIPyHON/d0/Up+PBo6XkQ==
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -3972,6 +4019,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.get@^4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -4121,6 +4173,11 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
+
+memoize-one@^5.0.4:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memory-fs@^0.4.0, memory-fs@^0.4.1:
   version "0.4.1"
@@ -5632,6 +5689,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+preact-css-transition-group@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/preact-css-transition-group/-/preact-css-transition-group-1.3.0.tgz#06fe468b26f7802e95b829a762db0bc199aef399"
+  integrity sha1-Bv5Giyb3gC6VuCmnYtsLwZmu85k=
+
 preact@8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
@@ -6013,6 +6075,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This removes derivatives processing from the promote job and adds in the Uppy dashboard. We can test uploading of batches of large videos or files and see how that works without trying to do any derivative creation.
![Screen Shot 2019-09-16 at 12 25 58 PM](https://user-images.githubusercontent.com/312085/64975505-2c76b700-d87d-11e9-9214-5792204dd34d.png)
